### PR TITLE
适配4.25及以后版本，以及避免触发C4800错误

### DIFF
--- a/Source/UnLua/Private/BaseLib/LuaLib_FFileHelper.cpp
+++ b/Source/UnLua/Private/BaseLib/LuaLib_FFileHelper.cpp
@@ -112,7 +112,7 @@ static int32 FFileHelper_SaveArrayToFile(lua_State *L)
 
 		if (NumParams == 3)
 		{
-			bAppend = lua_toboolean(L, 3);
+			bAppend = (lua_toboolean(L, 3) != 0);
 		}
 		
 

--- a/Source/UnLua/Private/BaseLib/LuaLib_FPaths.cpp
+++ b/Source/UnLua/Private/BaseLib/LuaLib_FPaths.cpp
@@ -71,7 +71,11 @@ BEGIN_EXPORT_CLASS(FPaths)
 	ADD_STATIC_FUNCTION_EX("ProjectUserDir", FString, ProjectUserDir)
 	ADD_STATIC_FUNCTION_EX("ProjectContentDir", FString, ProjectContentDir)
 	ADD_STATIC_FUNCTION_EX("ProjectConfigDir", FString, ProjectConfigDir)
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION <= 24
 	ADD_STATIC_FUNCTION_EX("ProjectSavedDir", FString, ProjectSavedDir)
+#else
+	ADD_STATIC_FUNCTION_EX("ProjectSavedDir", const FString&, ProjectSavedDir)
+#endif
 	ADD_STATIC_FUNCTION_EX("ProjectIntermediateDir", FString, ProjectIntermediateDir)
 	ADD_STATIC_FUNCTION_EX("ProjectPluginsDir", FString, ProjectPluginsDir)
 	ADD_STATIC_FUNCTION_EX("ProjectLogDir", FString, ProjectLogDir)


### PR DESCRIPTION
4.25-4.26版本更改了`ProjectSavedDir`函数的返回参数，因此无法在4.25-4.26版本的UE4中使用此repo。更改了`ADD_STATIC_FUNCTION_EX`传入的参数后即可解决这个问题。在更改后的版本中通过宏定义来判断是否是4.25-4.26的UE4来切换输入到`ADD_STATIC_FUNCTION_EX`的参数，在解决了4.25-4.26版本不能使用的问题的同时保证了旧版本引擎的正常使用。

此外，VS 2019将把`int`隐式转换成`bool`的行为从level 3 warning升级为level 4 warning，在某些情况下会直接报错打断编译。因此我修改了LuaLib_FFileHelper.cpp的115行，直接返回结果前添加上了公式进行转换，避免在VS 2019中报C4800错误。